### PR TITLE
More validation

### DIFF
--- a/usercss.go
+++ b/usercss.go
@@ -87,9 +87,7 @@ func ParseFromString(data string) *UserCSS {
 				uc.HintErrors = append(uc.HintErrors, Error{Name: "unknown", Code: ErrEmptyHead})
 				head = "unknown"
 			}
-			if tail == "" {
-				uc.HintErrors = append(uc.HintErrors, Error{Name: head, Code: ErrEmptyField})
-			}
+			knownValue := true
 
 			switch head {
 			case "@name":
@@ -146,6 +144,16 @@ func ParseFromString(data string) *UserCSS {
 			case "@-moz-document":
 				tail = strings.TrimRight(tail, " {")
 				ParseDomains(tail, uc)
+			// All unkown values will be executing this code
+			default:
+				knownValue = false
+			}
+
+			// If we handle this value only then check if tail is empty.
+			if knownValue {
+				if tail == "" {
+					uc.HintErrors = append(uc.HintErrors, Error{Name: head, Code: ErrEmptyField})
+				}
 			}
 		}
 	}

--- a/usercss.go
+++ b/usercss.go
@@ -15,6 +15,7 @@ var (
 	ErrEmptyVersion      = errors.New("@version field cannot be empty")
 	ErrMultipleOccurence = errors.New("duplicate occurence has been found in metadata")
 	ErrEmptyField        = errors.New("metadata field is empty")
+	ErrEmptyHead         = errors.New("metadata identifier is empty")
 )
 
 type UserCSS struct {
@@ -82,6 +83,10 @@ func ParseFromString(data string) *UserCSS {
 			head := parts[0]
 			tail := strings.TrimSpace(strings.Join(parts[1:], " "))
 
+			if head == "@" {
+				uc.HintErrors = append(uc.HintErrors, Error{Name: "unknown", Code: ErrEmptyHead})
+				head = "unknown"
+			}
 			if tail == "" {
 				uc.HintErrors = append(uc.HintErrors, Error{Name: head, Code: ErrEmptyField})
 			}

--- a/usercss.go
+++ b/usercss.go
@@ -14,6 +14,7 @@ var (
 	ErrEmptyNamespace    = errors.New("@namespace field cannot be empty")
 	ErrEmptyVersion      = errors.New("@version field cannot be empty")
 	ErrMultipleOccurence = errors.New("duplicate occurence has been found in metadata")
+	ErrEmptyField        = errors.New("metadata field is empty")
 )
 
 type UserCSS struct {
@@ -80,6 +81,10 @@ func ParseFromString(data string) *UserCSS {
 			// Metadata fields.
 			head := parts[0]
 			tail := strings.TrimSpace(strings.Join(parts[1:], " "))
+
+			if tail == "" {
+				uc.HintErrors = append(uc.HintErrors, Error{Name: head, Code: ErrEmptyField})
+			}
 
 			switch head {
 			case "@name":

--- a/usercss_test.go
+++ b/usercss_test.go
@@ -67,9 +67,17 @@ var (
 @namespace	somespace
 @version	1.0.1
 ==/UserStyle== */`
+	multipleOccurence = `/*==UserStyle==
+@name       newstyle
+@name       Awesome stlye!
+@namespace  somespace
+@version    1.0.1
+==/UserStyle== */`
 )
 
 func TestValidationPass(t *testing.T) {
+	t.Parallel()
+
 	uc := ParseFromString(ucPass)
 	err := BasicMetadataValidation(uc)
 	if err != nil {
@@ -78,6 +86,8 @@ func TestValidationPass(t *testing.T) {
 }
 
 func TestValidationFail(t *testing.T) {
+	t.Parallel()
+
 	uc := ParseFromString(ucFail)
 	err := BasicMetadataValidation(uc)
 	if err == nil {
@@ -86,6 +96,8 @@ func TestValidationFail(t *testing.T) {
 }
 
 func TestAuthor(t *testing.T) {
+	t.Parallel()
+
 	data := ParseFromString(ucPass)
 	pass := Author{
 		Name:    "Temp",
@@ -102,6 +114,8 @@ func TestAuthor(t *testing.T) {
 }
 
 func TestSingleDomain(t *testing.T) {
+	t.Parallel()
+
 	data := ParseFromString(domain)
 	pass := Domain{
 		Key:   "domain",
@@ -114,6 +128,8 @@ func TestSingleDomain(t *testing.T) {
 }
 
 func TestMultipleDomains(t *testing.T) {
+	t.Parallel()
+
 	data := ParseFromString(ucPass)
 	pass := []Domain{
 		{
@@ -139,6 +155,8 @@ func TestMultipleDomains(t *testing.T) {
 }
 
 func TestValidRemoteUserCSS(t *testing.T) {
+	t.Parallel()
+
 	URL := "https://raw.githubusercontent.com/vednoc/dark-github/main/github.user.styl"
 
 	// Test will fail if URL is invalid.
@@ -154,16 +172,19 @@ func TestValidRemoteUserCSS(t *testing.T) {
 }
 
 func TestInvalidRemoteUserCSS(t *testing.T) {
+	t.Parallel()
+
 	URL := "https:///raw.githubusercontent.com/vednoc/dark-github/main/github.user.styl"
 
 	// Test will fail because protocol has three slashes instead of two.
-	_, err := ParseFromURL(URL)
-	if err == nil {
+	if _, err := ParseFromURL(URL); err == nil {
 		t.Fatalf("Error parsing from URL: %v", err)
 	}
 }
 
 func TestUserCSS(t *testing.T) {
+	t.Parallel()
+
 	data := ParseFromString(ucPass)
 	pass := &UserCSS{
 		Name:         "Name",
@@ -206,6 +227,8 @@ func TestUserCSS(t *testing.T) {
 }
 
 func TestOverrideUpdateURL(t *testing.T) {
+	t.Parallel()
+
 	data := ParseFromString(ucPass)
 
 	url := "https://example.com/api/style/1.user.css"
@@ -217,6 +240,8 @@ func TestOverrideUpdateURL(t *testing.T) {
 }
 
 func TestMetadataWithTabs(t *testing.T) {
+	t.Parallel()
+
 	data := ParseFromString(tabs)
 	pass := &UserCSS{
 		Name:       "newstyle",
@@ -230,5 +255,14 @@ func TestMetadataWithTabs(t *testing.T) {
 
 	if dataString != passString {
 		t.Fatal("UserCSS structs don't match.")
+	}
+}
+
+func TestMultipleOccurenceMetadata(t *testing.T) {
+	t.Parallel()
+
+	uc := ParseFromString(multipleOccurence)
+	if err := BasicMetadataValidation(uc); len(err) != 1 || err[0].Name != "name" {
+		t.Fatal("Multiple occurence validation should return error")
 	}
 }

--- a/usercss_test.go
+++ b/usercss_test.go
@@ -1,6 +1,7 @@
 package usercss
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -70,6 +71,12 @@ var (
 	multipleOccurence = `/*==UserStyle==
 @name       newstyle
 @name       Awesome stlye!
+@namespace  somespace
+@version    1.0.1
+==/UserStyle== */`
+	emptyField = `/*==UserStyle==
+@name       newstyle
+@author
 @namespace  somespace
 @version    1.0.1
 ==/UserStyle== */`
@@ -262,7 +269,16 @@ func TestMultipleOccurenceMetadata(t *testing.T) {
 	t.Parallel()
 
 	uc := ParseFromString(multipleOccurence)
-	if err := BasicMetadataValidation(uc); len(err) != 1 || err[0].Name != "name" {
+	if err := BasicMetadataValidation(uc); len(err) != 1 || !errors.Is(err[0].Code, ErrMultipleOccurence) || err[0].Name != "name" {
+		t.Fatal("Multiple occurence validation should return error")
+	}
+}
+
+func TestEmptyField(t *testing.T) {
+	t.Parallel()
+
+	uc := ParseFromString(emptyField)
+	if err := BasicMetadataValidation(uc); len(err) != 1 || !errors.Is(err[0].Code, ErrEmptyField) || err[0].Name != "@author" {
 		t.Fatal("Multiple occurence validation should return error")
 	}
 }

--- a/usercss_test.go
+++ b/usercss_test.go
@@ -80,6 +80,12 @@ var (
 @namespace  somespace
 @version    1.0.1
 ==/UserStyle== */`
+	emptyIdentifier = `/*==UserStyle==
+@name       newstyle
+@	Me
+@namespace  somespace
+@version    1.0.1
+==/UserStyle== */`
 )
 
 func TestValidationPass(t *testing.T) {
@@ -279,6 +285,15 @@ func TestEmptyField(t *testing.T) {
 
 	uc := ParseFromString(emptyField)
 	if err := BasicMetadataValidation(uc); len(err) != 1 || !errors.Is(err[0].Code, ErrEmptyField) || err[0].Name != "@author" {
+		t.Fatal("Multiple occurence validation should return error")
+	}
+}
+
+func TestEmptyIdentifier(t *testing.T) {
+	t.Parallel()
+
+	uc := ParseFromString(emptyIdentifier)
+	if err := BasicMetadataValidation(uc); len(err) != 1 || !errors.Is(err[0].Code, ErrEmptyHead) {
 		t.Fatal("Multiple occurence validation should return error")
 	}
 }


### PR DESCRIPTION
Such things as
```CSS
/*==UserStyle==
@name       newstyle
@name       Awesome stlye!
@namespace  somespace
@version    1.0.1
==/UserStyle== */
```
should return a error on metadata validation.